### PR TITLE
Fix references to `cellpose` and add M1 Mac instructions

### DIFF
--- a/napari-workshops/SciPy-0722/notebook_setup.md
+++ b/napari-workshops/SciPy-0722/notebook_setup.md
@@ -50,7 +50,7 @@ jupyter notebook
 Jupyter Notebook will open in a browser window and you will see the following notebooks:
 
 - `part_0_viewer_intro.ipynb`: in this activity, you will gain familiarity with loading and viewing images in napari.
-- `part_1_segmenting_and_measuring_nuclei.ipynb`: in this notebook, you will use cellpose to segment nuclei and scikit-image to measure them.
+- `part_1_segmenting_and_measuring_nuclei.ipynb`: in this notebook, you will use stardist to segment nuclei and scikit-image to measure them.
 - `part_2_spot_detection_tutorial_beginner.ipynb`: this is the spot detection notebook for people new to image processing with python
 - `part_2_spot_detection_tutorial_advanced.ipynb`: this is the spot detection notebook for people with experience performing image processing with python
 - `part_2_spot_detection_tutorial_solution.ipynb`: this is the solution to the spot detection activity.

--- a/napari-workshops/SciPy-0722/scipy_installation.md
+++ b/napari-workshops/SciPy-0722/scipy_installation.md
@@ -79,6 +79,16 @@ In this tutorial, we will install python via miniforge, a distribution of anacon
 
 4. Install the dependencies with the commands below
 
+	**If you're on an M1 Mac**:
+
+	```bash
+	conda install -c conda-forge notebook napari
+	pip install cookiecutter magicgui
+	pip install stardist-napari
+	```
+
+	Other systems: 
+
 	```bash
 	conda install -c conda-forge notebook
 	pip install cookiecutter magicgui "napari[all]"
@@ -91,7 +101,19 @@ In this tutorial, we will install python via miniforge, a distribution of anacon
 	conda install -c conda-forge python.app
 	```
 
-```{admonition} Got an M1 Mac?
+6. Test that your notebook installation is working. We will be using notebook for interactive analysis. Enter the command below and it should launch jupyter notebook book in a web browser. Once you've confirmed it launches, close the web browser and press ctrl+c in the terminal window to stop the notebook server.
+
+	```bash
+	jupyter notebook
+	```
+
+7. Test your napari installation. Enter the command below and an empty napari viewer should open. You can close the window after it opens. Please note that it takes a bit of extra time to launch napari the first time.
+	
+	```bash
+	napari
+	```
+
+```{admonition} Errors launching?
 Sometimes, `napari` installation can fail on an M1 Mac due to mismatching dependencies on `pip`.
 
 If you get an error at step 4 above, or can't launch `napari` after installation, 
@@ -120,15 +142,3 @@ pip install stardist-napari
 ````
 
 ```
-
-6. Test that your notebook installation is working. We will be using notebook for interactive analysis. Enter the command below and it should launch jupyter notebook book in a web browser. Once you've confirmed it launches, close the web browser and press ctrl+c in the terminal window to stop the notebook server.
-
-	```bash
-	jupyter notebook
-	```
-
-7. Test your napari installation. Enter the command below and an empty napari viewer should open. You can close the window after it opens. Please note that it takes a bit of extra time to launch napari the first time.
-	
-	```bash
-	napari
-	```

--- a/napari-workshops/SciPy-0722/scipy_installation.md
+++ b/napari-workshops/SciPy-0722/scipy_installation.md
@@ -91,6 +91,36 @@ In this tutorial, we will install python via miniforge, a distribution of anacon
 	conda install -c conda-forge python.app
 	```
 
+```{admonition} Got an M1 Mac?
+Sometimes, `napari` installation can fail on an M1 Mac due to mismatching dependencies on `pip`.
+
+If you get an error at step 4 above, or can't launch `napari` after installation, 
+you should try to delete your `napari-tutorial` environment, and follow the installation instructions here.
+
+1. Delete your `napari-tutorial` environment
+
+````bash
+conda activate base
+conda env remove -n napari-tutorial
+````
+
+2. Create your environment and install `napari` from `conda-forge`
+
+````bash
+conda create -y -n napari-tutorial python=3.9 napari
+````
+
+Then after creation:
+
+````bash
+conda activate napari-tutorial
+conda install -c conda-forge notebook
+pip install cookiecutter magicgui
+pip install stardist-napari
+````
+
+```
+
 6. Test that your notebook installation is working. We will be using notebook for interactive analysis. Enter the command below and it should launch jupyter notebook book in a web browser. Once you've confirmed it launches, close the web browser and press ctrl+c in the terminal window to stop the notebook server.
 
 	```bash

--- a/napari-workshops/notebooks/segmenting_and_measuring_nuclei_stardist.md
+++ b/napari-workshops/notebooks/segmenting_and_measuring_nuclei_stardist.md
@@ -166,4 +166,4 @@ plt.show()
 
 ## Conclusions
 
-In this notebook, we have used the cellpose-napari plugin to perform nucleus segmentation. We then used the results of the segmentation to inspect the relationship between nucleus area and circularity. This demonstration highlights how one can combine napari plugins and python libraries to make measurements on microscopy data.
+In this notebook, we have used the stardist-napari plugin to perform nucleus segmentation. We then used the results of the segmentation to inspect the relationship between nucleus area and circularity. This demonstration highlights how one can combine napari plugins and python libraries to make measurements on microscopy data.


### PR DESCRIPTION
Pinging @kevinyamauchi I've updated the install instructions to include info for M1 macs. Also removed errant references to `cellpose`